### PR TITLE
Mark Quiver Mini as paused

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,22 +15,26 @@ Quiver is a capable 25kg VTOL platform — but it's expensive and complex to bui
 
 ## Status
 
-🟡 **Design phase** — community discussion open. See [`docs/design-brief.md`](docs/design-brief.md) for open questions.
+⏸️ **Paused / community-maintained** — Quiver Mini remains an open concept for a future purpose-built small Quiver platform, but Arrow is not actively managing clean-sheet Mini development right now.
+
+Contributions, experiments, and design notes are still welcome. Expect slower review and less active coordination until the project is reprioritized.
+
+Near-term small-platform work is shifting toward documenting and flying **Kestrel**, Julius's flown 5kg-class reference build that reuses existing Quiver electronics/PCBs.
 
 ## Reference Builds
 
 | Build | Author | Status | Notes |
 |-------|--------|--------|-------|
-| [Kestrel](reference-builds/kestrel/) | Julius (far1no) | Parts ordered | 5kg quad, MAD 4x08, 6S, Quiver body |
+| [Kestrel](reference-builds/kestrel/) | Julius (far1no) | Flown | 5kg quad, MAD 4x08, 6S, Quiver body + Quiver PCBs |
 
-Reference builds are community members' individual interpretations of the Quiver Mini concept. They inform the official design but are not the spec.
+Reference builds are community members' individual interpretations of the small-Quiver concept. Kestrel is being uploaded and documented separately as the practical near-term small platform/reference build; Quiver Mini remains the future clean-sheet design path.
 
 ## Repository Structure
 
 ```
 project-quiver-mini/
 ├── docs/
-│   ├── design-brief.md        # Open design questions for community discussion
+│   ├── design-brief.md        # Preserved design direction and paused-project status
 │   └── decisions/             # Log of design decisions and rationale
 ├── reference-builds/
 │   └── kestrel/               # Julius's Kestrel reference build
@@ -39,9 +43,9 @@ project-quiver-mini/
 
 ## Contributing
 
-This project is coordinated through the Arrow Discord server — join `#quiver-mini` to participate in design discussions.
+This project is currently paused rather than actively coordinated. Join the Arrow Discord server and use `#quiver-mini` for design discussion, but please assume maintainers may be slow to respond.
 
-Arrow DAO is an experiment in open, community-led hardware development. Contributions of all kinds are welcome: CAD, simulation, firmware, documentation, testing.
+Arrow DAO is an experiment in open, community-led hardware development. Contributions of all kinds are welcome: CAD, simulation, firmware, documentation, testing. For now, the most useful contributions are small, well-scoped notes, experiments, comparisons against Kestrel, or PRs that clearly improve the archived design direction without requiring heavy maintainer coordination.
 
 ## License
 

--- a/docs/bounties/frame-design.md
+++ b/docs/bounties/frame-design.md
@@ -25,9 +25,9 @@ A CAD design for the Quiver Mini v1 frame — a quad frame for a 7kg MTOW sensor
 | Diagonal wheelbase | ~700–730mm (motor-to-motor) |
 | Motor mount | Hobbywing X6-SE 25mm clamp (primary); T-Motor M3×4 bolt circle (secondary) |
 | Attachment interface | Single bottom port, Quiver-compatible, centered on belly |
-| CAN wiring | Cable routing channels from arm tubes into central hub |
+| ESC/signal wiring | Cable routing channels from arm tubes into central hub; support DSHOT/PWM v1 and leave room for future CAN wiring |
 | Power connector | XT90-S antispark, battery bay accessible without opening enclosure |
-| Battery bay | Design to fit 6S 22Ah reference pack: **200×95×75mm** (max envelope); Velcro strap mount, ~2kg |
+| Battery bay | Design to fit 6S 14Ah reference pack: **~200×75×65mm** target envelope; Velcro strap mount, ~1.6–1.8kg |
 
 ---
 
@@ -92,6 +92,6 @@ The frame has two distinct material zones:
 
 ## Resources
 
-- [ADR-007: Propulsion (Hobbywing X6-SE specs)](decisions/ADR-007-propulsion.md)
-- [Design brief](design-brief.md)
-- [Kestrel reference build](../reference-builds/kestrel/README.md)
+- [ADR-007: Propulsion (Hobbywing X6-SE specs)](../decisions/ADR-007-propulsion.md)
+- [Design brief](../design-brief.md)
+- Kestrel reference build (Julius) — documented in project notes; formal reference-build folder TBD

--- a/docs/bounties/frame-design.md
+++ b/docs/bounties/frame-design.md
@@ -1,11 +1,17 @@
 # Bounty: Quiver Mini Frame Design
 
-**Status:** Open  
-**Reward:** 8,000 $ARROW  
-**Repo:** [Arrow-air/project-quiver-mini](https://github.com/Arrow-air/project-quiver-mini)  
-**Related ADRs:** ADR-001 (MTOW), ADR-003 (Quad), ADR-006 (Arms), ADR-007 (Propulsion)
+- **Status:** Paused — not currently funded or actively managed
+- **Reward:** 8,000 $ARROW (draft / not active)
+- **Repo:** [Arrow-air/project-quiver-mini](https://github.com/Arrow-air/project-quiver-mini)
+- **Related ADRs:** ADR-001 (MTOW), ADR-003 (Quad), ADR-006 (Arms), ADR-007 (Propulsion)
 
 ---
+
+## Current note
+
+This bounty spec is preserved as a draft for a future Quiver Mini restart. Arrow is not actively managing this bounty right now, and contributors should not assume the reward is available until the project is formally reprioritized.
+
+For near-term small-platform work, see the Kestrel reference build path.
 
 ## What we need
 

--- a/docs/bounties/pcb-design.md
+++ b/docs/bounties/pcb-design.md
@@ -23,12 +23,12 @@ The Quiver Main PCB is a useful reference, but Quiver is 14S and 25kg — Mini n
 | Max continuous input current | ≥80A (4× motors, peaks to 20A+ per motor) |
 | Board outline | Fit within **~180×120mm** (see frame bounty interior spec: 190×130mm minimum bay) |
 | Mounting pattern | 4× M3 standoffs, compatible with FC PCB stack (30.5×30.5mm or 45×45mm patterns) |
-| Motor interface | 4× 3-pin CAN headers (Hobbywing X6-SE CAN) |
+| Motor interface | 4× DSHOT/PWM ESC signal outputs for v1; optional 4× CAN headers/pads for future Hobbywing telemetry |
 | Power output — CAN bus | 5V regulated, ≥500mA |
 | Power output — avionics | 5V, ≥3A (Flight controller, companion computer) |
-| Power output — payloads | 5V and 12V rails for attachment interface PCBs (left, bottom, right ports) |
+| Power output — payloads | 5V and 12V rails for the single bottom attachment interface PCB |
 | Battery connector | XT90-S (antispark) |
-| ESC architecture | 4× individual CAN connections (not centralized ESC) |
+| ESC architecture | 4× individual integrated ESC/motor assemblies; DSHOT/PWM primary for v1, CAN optional/future |
 
 ---
 
@@ -36,16 +36,16 @@ The Quiver Main PCB is a useful reference, but Quiver is 14S and 25kg — Mini n
 
 ### Power distribution
 - Main 6S bus distribution to 4× motor outputs (direct battery voltage, no conversion)
-- Pre-charge circuit for XT90-S antispark (or equivalent soft-start)
+- No dedicated pre-charge circuit for v1; use XT90-S antispark per ADR-005
 - Polarity protection
 - Blade fuses or PTC protection on regulated rails
 - Voltage and current monitoring on main bus (for ArduPilot BATTERY monitor — compatible IC preferred: INA226 or INA3221)
 
-### CAN bus
-- Dual CAN bus (CAN1, CAN2) — standard ArduPilot multi-bus topology
-- 4× motor connections on CAN1
-- CAN2 available for peripherals (GPS, rangefinder, LIDAR)
-- 120Ω termination resistors, selectable via jumper
+### ESC signal and CAN bus
+- 4× DSHOT/PWM motor signal outputs as the v1 baseline for ArduPilot compatibility and lower integration risk
+- CAN remains a preferred future/optional path for Hobbywing telemetry; include connector pads or documented expansion path if feasible
+- CAN bus available for peripherals (GPS, rangefinder, LIDAR)
+- 120Ω termination resistors, selectable via jumper where CAN is implemented
 
 ### FC interface
 - Standard ArduPilot Pixhawk connector pinout
@@ -54,9 +54,9 @@ The Quiver Main PCB is a useful reference, but Quiver is 14S and 25kg — Mini n
 - ADC input for battery voltage/current passthrough to FC
 
 ### Attachment interface
-- 3× attachment port connectors (bottom, left, right) matching Quiver pogo-pin PCB footprint
-- 5V and 12V switched power per port (enable via FC GPIO or dedicated power switch IC)
-- CAN or UART passthrough to each attachment port (at minimum UART; CAN preferred)
+- 1× bottom attachment port connector matching the Quiver pogo-pin PCB footprint
+- 5V and 12V switched power to the attachment port (enable via FC GPIO or dedicated power switch IC)
+- UART passthrough to the attachment port minimum; CAN preferred if routing/connector budget allows
 
 ### Indicators & connectors
 - Power LED (board live indicator)
@@ -109,8 +109,8 @@ Deviations from this target are acceptable with justification in the design note
 
 ## Reference
 
-- [ADR-007: Propulsion (Hobbywing X6-SE CAN specs)](decisions/ADR-007-propulsion.md)
-- [ADR-002: Enclosure](decisions/ADR-002-enclosure.md)
+- [ADR-007: Propulsion (Hobbywing X6-SE specs)](../decisions/ADR-007-propulsion.md)
+- [ADR-002: Enclosure](../decisions/ADR-002-enclosure.md)
 - [Frame design bounty](frame-design.md) — interior bay dimensions are defined there; PCB must fit within that envelope
 - [Design brief](../design-brief.md)
 - Quiver Main PCB (existing full Quiver design) — available in project-quiver repo as reference; adapt for 6S, do not copy directly

--- a/docs/bounties/pcb-design.md
+++ b/docs/bounties/pcb-design.md
@@ -1,11 +1,17 @@
 # Bounty: Quiver Mini Main PCB Design
 
-**Status:** Open  
-**Reward:** 7,000 $ARROW  
-**Repo:** [Arrow-air/project-quiver-mini](https://github.com/Arrow-air/project-quiver-mini)  
-**Related ADRs:** ADR-001 (MTOW), ADR-002 (Enclosure), ADR-007 (Propulsion)
+- **Status:** Paused — not currently funded or actively managed
+- **Reward:** 7,000 $ARROW (draft / not active)
+- **Repo:** [Arrow-air/project-quiver-mini](https://github.com/Arrow-air/project-quiver-mini)
+- **Related ADRs:** ADR-001 (MTOW), ADR-002 (Enclosure), ADR-007 (Propulsion)
 
 ---
+
+## Current note
+
+This bounty spec is preserved as a draft for a future Quiver Mini restart. Arrow is not actively managing this bounty right now, and contributors should not assume the reward is available until the project is formally reprioritized.
+
+For near-term small-platform work, Kestrel reuses existing Quiver PCBs rather than requiring a new Mini PCB.
 
 ## What we need
 

--- a/docs/decisions/ADR-007-propulsion.md
+++ b/docs/decisions/ADR-007-propulsion.md
@@ -72,3 +72,8 @@ Document 2–3 validated options before first build. Motor mount adapter at the 
 - CAN bus wiring must be routed through arms to central PCB
 - PCB must include CAN interface (or FC handles CAN passthrough)
 - Heavier propulsion system than originally estimated — enclosure and arm design must account for this
+
+
+## Implementation note — May 2026
+
+The first PCB bounty uses **DSHOT/PWM as the v1 ESC control baseline** for ArduPilot compatibility and lower integration risk. Hobbywing CAN telemetry remains valuable, but is treated as optional/future unless the PCB designer can include it cleanly without delaying the first board. Frame wiring should leave a path for future CAN even if v1 flies on DSHOT/PWM.

--- a/docs/design-brief.md
+++ b/docs/design-brief.md
@@ -2,7 +2,7 @@
 
 This document summarizes the key design decisions for Quiver Mini. Decisions were made through community discussion in `#quiver-mini` on the Arrow Discord and are recorded in `docs/decisions/`.
 
-**Last updated:** 2026-03-05  
+**Last updated:** 2026-05-06  
 **Status:** v1 spec locked — moving to design phase
 
 ---
@@ -39,6 +39,20 @@ Full rationale in `docs/decisions/`. Summary:
 
 ---
 
+## v0.1 Implementation Baseline (May 2026)
+
+These defaults are used for the first frame and PCB bounty scopes. They refine the locked ADR direction without reopening the core design decisions.
+
+| Area | Baseline |
+|------|----------|
+| Reference motor | Hobbywing X6-SE 380KV primary; T-Motor MN5008 backup path |
+| Propeller | HF18×6.0-ish reference prop |
+| Frame geometry | ~700–730mm diagonal motor-to-motor wheelbase for 18" prop clearance |
+| Battery bay | 6S 14Ah reference pack, ~200×75×65mm target envelope |
+| ESC interface | DSHOT/PWM primary for PCB v1; CAN pads/headers optional/future for Hobbywing telemetry |
+| Attachment port | Single bottom Quiver-compatible interface only |
+| Power-on | XT90-S antispark, no dedicated pre-charge circuit for v1 |
+
 ## Reference Builds
 
 ### Kestrel (Julius / far1no)
@@ -70,8 +84,7 @@ From community input during the discussion phase:
 
 ## Next Steps
 
-- [ ] Enclosure CAD (bounty)
-- [ ] Motor mount adapter design (bounty — universal arm-tip interface)
-- [ ] Validate T-Motor MN5008 KV340 and 2 alternatives at 6S
-- [ ] Frame geometry / wheelbase calculation based on propulsion choice
+- [ ] Publish frame/enclosure CAD bounty
+- [ ] Publish PCB design bounty
+- [ ] Validate Hobbywing X6-SE + T-Motor MN5008 backup path at 6S
 - [ ] First-pass BOM

--- a/docs/design-brief.md
+++ b/docs/design-brief.md
@@ -2,8 +2,8 @@
 
 This document summarizes the key design decisions for Quiver Mini. Decisions were made through community discussion in `#quiver-mini` on the Arrow Discord and are recorded in `docs/decisions/`.
 
-**Last updated:** 2026-05-06  
-**Status:** v1 spec locked — moving to design phase
+- **Last updated:** 2026-05-21
+- **Status:** Paused / community-maintained — v1 spec notes preserved, but active Arrow-managed clean-sheet development is on hold
 
 ---
 
@@ -18,7 +18,7 @@ These are inherited from Quiver or set by project goals:
 | Flight stack | ArduCopter | Proven, open-source |
 | Battery system | 6S | Right voltage class for 5–10kg; Kestrel build confirms |
 | Video/comms | SIYI camera + HM30 (likely) | Proven on Quiver; consistent ecosystem |
-| Open source | Apache 2.0 | Yes |
+| Open source | CERN-OHL-S v2 for hardware; GPL-3.0 for software | Keeps hardware/software derivatives open source |
 
 ---
 
@@ -39,9 +39,15 @@ Full rationale in `docs/decisions/`. Summary:
 
 ---
 
-## v0.1 Implementation Baseline (May 2026)
+## Current Project Direction (May 2026)
 
-These defaults are used for the first frame and PCB bounty scopes. They refine the locked ADR direction without reopening the core design decisions.
+Quiver Mini is paused as an actively managed clean-sheet project. The repo remains open for contributions, experiments, and design notes, but Arrow is not currently funding or coordinating the frame/PCB bounty path.
+
+Near-term small-platform energy is shifting toward documenting and flying Kestrel: Julius's 5kg-class flown reference build using the Quiver enclosure and existing Quiver PCBs. Kestrel is not the final Mini spec; it is the practical near-term platform and learning vehicle.
+
+## v0.1 Implementation Baseline (preserved)
+
+These defaults were prepared for the first frame and PCB bounty scopes. They refine the locked ADR direction without reopening the core design decisions. They are preserved for future restart, but should not be treated as active work items while the project is paused.
 
 | Area | Baseline |
 |------|----------|
@@ -56,7 +62,7 @@ These defaults are used for the first frame and PCB bounty scopes. They refine t
 ## Reference Builds
 
 ### Kestrel (Julius / far1no)
-*Personal build, parallel to the community design. Informs v1 decisions.*
+*Julius's flown 5kg-class reference build. Practical near-term small platform; informs any future Mini restart.*
 
 | Spec | Value |
 |------|-------|
@@ -84,7 +90,9 @@ From community input during the discussion phase:
 
 ## Next Steps
 
-- [ ] Publish frame/enclosure CAD bounty
-- [ ] Publish PCB design bounty
-- [ ] Validate Hobbywing X6-SE + T-Motor MN5008 backup path at 6S
-- [ ] First-pass BOM
+Active Arrow-managed Mini development is paused. If/when the project is restarted:
+
+- [ ] Review Kestrel flight/build data against the Mini v1 goals
+- [ ] Decide whether the clean-sheet Mini path is still needed and what it should optimize beyond Kestrel
+- [ ] Reconfirm or revise the v0.1 implementation baseline
+- [ ] Reopen frame/enclosure and PCB bounty scopes only after bandwidth/funding is available

--- a/docs/governance/snapshot-proposal-draft.md
+++ b/docs/governance/snapshot-proposal-draft.md
@@ -1,17 +1,19 @@
 # Snapshot Proposal Draft: Quiver Mini v1 Development Fund
 
-**Status:** Draft — not yet submitted  
-**Proposed by:** thomasg  
-**Amount requested:** 25,000 $ARROW  
-**Target wallet:** TBD
+- **Status:** Paused draft — not active / not submitted
+- **Proposed by:** thomasg
+- **Amount requested:** 25,000 $ARROW
+- **Target wallet:** TBD
 
 ---
 
 ## Summary
 
-Allocate **25,000 $ARROW** to fund the technical development bounties required to bring Quiver Mini v1 from locked design decisions to a documented, repeatable first build.
+This draft is preserved for a possible future restart, but it is not active. Arrow is not currently pursuing the Quiver Mini bounty/Snapshot path.
 
-Quiver Mini is an Arrow community project to build a smaller, lighter Quiver variant — a 7kg MTOW open-source quad drone optimized for sensor payloads (cameras, LiDAR, thermal, multispectral). The project repo is live, design decisions are locked, and the first technical bounties are ready to post. This proposal funds the bounty pool.
+The original intent was to allocate **25,000 $ARROW** to fund the technical development bounties required to bring Quiver Mini v1 from locked design decisions to a documented, repeatable first build.
+
+Quiver Mini is an Arrow community project to build a smaller, lighter Quiver variant — a 7kg MTOW open-source quad drone optimized for sensor payloads (cameras, LiDAR, thermal, multispectral). The project repo is live and design decisions are preserved, but active clean-sheet development is paused while near-term small-platform work shifts toward documenting and flying Kestrel.
 
 ---
 
@@ -53,6 +55,8 @@ All bounties are paid in **$ARROW only** at an internal reference price of **$0.
 
 ## Process
 
+If this proposal is revived:
+
 - Bounties are posted individually to #grants-and-bounties as funding is confirmed
 - Claims via GitHub issue on [Arrow-air/project-quiver-mini](https://github.com/Arrow-air/project-quiver-mini)
 - Review and payment processed per the standard Arrow bounty guide
@@ -64,6 +68,7 @@ All bounties are paid in **$ARROW only** at an internal reference price of **$0.
 
 | Milestone | Target |
 |-----------|--------|
+| Project reprioritized / proposal revived | TBD |
 | Snapshot vote passes | TBD |
 | Frame design bounty claimed | Within 2 weeks of posting |
 | Frame CAD delivered | 4–6 weeks after claim |

--- a/reference-builds/kestrel/README.md
+++ b/reference-builds/kestrel/README.md
@@ -1,12 +1,14 @@
 # Kestrel — Reference Build
 
-**Author:** Julius (far1no)  
-**Status:** Parts ordered, first build in progress (Feb 2026)  
-**Weight class:** ~5kg MTOW
+- **Author:** Julius (far1no)
+- **Status:** Flown; being documented as the practical near-term small platform/reference build
+- **Weight class:** ~5kg MTOW
 
 ---
 
-Kestrel is a personal build by Julius exploring the minimum viable Quiver Mini. Designed over a weekend hackathon in February 2026, it prioritizes maximum reuse of Quiver electronics to minimize new development.
+Kestrel is a personal build by Julius exploring a minimum viable small Quiver-class aircraft. Designed over a weekend hackathon in February 2026, it prioritizes maximum reuse of Quiver electronics to minimize new development.
+
+After Kestrel's first flights, Arrow is treating it as the practical near-term small platform/reference build while clean-sheet Quiver Mini development is paused.
 
 ## Key Specs
 
@@ -57,8 +59,8 @@ Kestrel is a personal build by Julius exploring the minimum viable Quiver Mini. 
 - ✅ MAD 4x08 + 15" props is a viable propulsion choice for 5kg
 - ✅ Quiver body size is functional (not optimal, but works)
 - ✅ Integrated motor-arm landing gear is a clean solution
-- ⏳ First flight data pending — will inform Quiver Mini design
+- ✅ First flights completed — use logs/build notes to inform any future Quiver Mini restart
 
 ## Files
 
-*CAD files to be added once build is complete and design is finalized.*
+*CAD files, logs, photos, and build notes to be added as they are cleaned up for publication.*


### PR DESCRIPTION
## Summary
- mark Quiver Mini as paused / community-maintained in the README and design brief
- keep contributions welcome, but set expectations that Arrow is not actively managing clean-sheet Mini development right now
- mark the frame, PCB, and Snapshot bounty docs as paused drafts rather than active/funded work
- update Kestrel references to reflect that it has flown and is the practical near-term small-platform/reference-build path
- preserve the previous v0.1 baseline updates for a future Mini restart

## Verification
- `git diff --check`
